### PR TITLE
Fix minor typos

### DIFF
--- a/check.cgi
+++ b/check.cgi
@@ -26,7 +26,7 @@ if __FILE__ == $0
 	puts
 
 	def print_problems(problems)
-		puts "Some problem occured:"
+		puts "Some problem occurred:"
 		print " - "
 		puts problems.collect{|a|
 			a.join("\n   ")
@@ -56,7 +56,7 @@ end
 
 
 unless File.exists?("locale/de/dudle.mo")
-	problems << ["If you want a language other than English, you will need a localization and therefore need ot build the .mo files. Refer the README for details."]
+	problems << ["If you want a language other than English, you will need a localization and therefore need to build the .mo files. Refer the README for details."]
 end
 
 unless File.writable?(".")
@@ -87,7 +87,7 @@ end
 
 rescue Exception => e
 	if problems.empty?
-		puts "Some problem occured. Please contact the developer:"
+		puts "Some problem occurred. Please contact the developer:"
 		pp e
 		puts e.backtrace.join("\n")
 	else

--- a/config_sample.rb
+++ b/config_sample.rb
@@ -51,7 +51,7 @@
 # You have 2 Options: 
 #   1. change logrotate to allow /var/log/apache2/* to be read by apache
 #      (=> change the line »create 640 root adm«)
-#   2. change $conf.errorlog to another file and creat a new rule for logrotate.
+#   2. change $conf.errorlog to another file and create a new rule for logrotate.
 #      DO NOT FORGET TO ADD THE ERROR LOG TO LOGROTATE IF YOU CHANGE THE PATH
 #      TO OTHER THAN /var/log/apache2/* !
 # If you do not know what to do what I am speaking about, just do not uncomment
@@ -59,7 +59,7 @@
 #$conf.errorlog = "/var/log/dudle_error.log"
 #$conf.bugreportmail = "webmaster@yoursite.example.org"
 
-# Send bug reports automatically with the programm “mail”
+# Send bug reports automatically with the program “mail”
 #$conf.auto_send_report = false
 
 # Add the following htmlcode to the startpage.

--- a/error.cgi
+++ b/error.cgi
@@ -50,7 +50,7 @@ end
 	errormessagebody = _("Hi!\n\nI found a bug in your application at %{urlofsite}.\nI did the following:\n\n<please describe what you did>\n<e.g., I wanted to sent a comment to the poll.>\n\nI am using <please state your browser and operating system>\n%{errormessage}\nYours,\n") % {:errormessage => errormessage, :urlofsite => $conf.siteurl}
 	subject = _("Bug in dudle")
 
-	$d << _("An error occured while executing dudle.<br/>Please send an error report, including your browser, operating system, and what you did to %{admin}.") % {:admin => "<a href='mailto:#{$conf.bugreportmail}?subject=#{urlescape(subject)}&amp;body=#{urlescape(errormessagebody)}'>#{$conf.bugreportmail}</a>"}
+	$d << _("An error occurred while executing dudle.<br/>Please send an error report, including your browser, operating system, and what you did to %{admin}.") % {:admin => "<a href='mailto:#{$conf.bugreportmail}?subject=#{urlescape(subject)}&amp;body=#{urlescape(errormessagebody)}'>#{$conf.bugreportmail}</a>"}
 
 if (errorstr)
 	errorheadstr = _("Please include the following as well:")

--- a/pollhead.rb
+++ b/pollhead.rb
@@ -33,7 +33,7 @@ class PollHead
 	end
 
 	# column is in human readable form
-	# returns true if deletion sucessfull
+	# returns true if deletion successful
 	def delete_column(column)
 		@data.delete(column) != nil
 	end

--- a/timepollhead.rb
+++ b/timepollhead.rb
@@ -99,7 +99,7 @@ class TimePollHead
 		parsed_date
 	end
 
-	# returns parsed title or nil in case of colum not changed
+	# returns parsed title or nil in case of column not changed
 	def edit_column(column, newtitle, cgi)
 		if cgi.include?("toggleallon")
 				head_count("%Y-%m-%d",false).each{|day,num|
@@ -125,7 +125,7 @@ class TimePollHead
 	end
 
 	# returns a sorted array, containing the big units and how often each small is in the big one
-	# small and big must be formated for strftime
+	# small and big must be formatted for strftime
 	# ex: head_count("%Y-%m") returns an array like [["2009-03",2],["2009-04",3]]
 	# if notime = true, the time field is stripped out before counting
 	def head_count(elem, notime)

--- a/vcs_git.rb
+++ b/vcs_git.rb
@@ -42,7 +42,7 @@ class VCS
 	end
 
 	def VCS.revno
-		# there is a bug in git log --format, which supresses the \n on the last line
+		# there is a bug in git log --format, which suppresses the \n on the last line
 		runcmd(GITCMD, "log", "--format=format:x").scan("\n").size + 1
 	end
 


### PR DESCRIPTION
Typos reported by `codespell -ef --skip "*.po"`