### PR TITLE
removing dead link to hub.docker.com in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ GNU AGPL v3 or higher (see file License)
     echo "<div>We are updating the servers and expect to be online on 0 am, January 1st, 1970 (UTC).</div>" > $DUDLE_INSTALLATION_PATH/maintenance.html
     ```
 
-# Docker image
+# image
 There are two docker image available
- *  https://hub.docker.com/r/fonk/dudle/ with the code from here https://github.com/fonk/docker-dudle
+ *  https://github.com/fonk/docker-dudle
  *  https://github.com/jpkorva/dudle-docker
 
 # Pimp your Installation


### PR DESCRIPTION
the `https://hub.docker.com/u/fonk/dudle` repository does not exist (anymore), so I have removed that link.