### PR TITLE
removing docker project fonk/dudle (which isn't maintained any longer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ GNU AGPL v3 or higher (see file License)
     echo "<div>We are updating the servers and expect to be online on 0 am, January 1st, 1970 (UTC).</div>" > $DUDLE_INSTALLATION_PATH/maintenance.html
     ```
 
-# Docker image
+# image
 There are two docker image available
- *  https://hub.docker.com/r/fonk/dudle/ with the code from here https://github.com/fonk/docker-dudle
+ *  https://github.com/fonk/docker-dudle
  *  https://github.com/jpkorva/dudle-docker
 
 # Pimp your Installation

--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ GNU AGPL v3 or higher (see file License)
     ```
 
 # image
-There are two docker image available
- *  https://github.com/fonk/docker-dudle
+There is a docker image available
  *  https://github.com/jpkorva/dudle-docker
 
 # Pimp your Installation


### PR DESCRIPTION
the fonk/dudle docker project is not maintained any longer apparently. 
So I removed the link to it from the README