### PR TITLE
Lingala localisation (L10N LN)

### DIFF
--- a/locale/ln/dudle.po
+++ b/locale/ln/dudle.po
@@ -40,7 +40,7 @@ msgstr "Application soutenue par %{DuDPoll}."
 
 #: ../about.cgi:31
 msgid "License"
-msgstr "License"
+msgstr "Lisásɛ"
 
 #: ../about.cgi:32
 msgid ""
@@ -58,15 +58,15 @@ msgstr "Le code source de l'application est disponible %{a_start}ici%{a_end}."
 
 #: ../access_control.rb:74 ../customize.cgi:82 ../customize.rb:82
 msgid "Username:"
-msgstr "Identifiant :"
+msgstr "Mosáleli:"
 
 #: ../access_control.rb:87
 msgid "Password"
-msgstr "Mot de passe"
+msgstr "Banda"
 
 #: ../access_control.rb:88
 msgid "repeat"
-msgstr "répéter"
+msgstr "Kobandela"
 
 #: ../access_control.rb:114
 msgid ""
@@ -79,12 +79,12 @@ msgstr ""
 #: ../access_control.rb:117 ../customize.cgi:119 ../customize.rb:119
 #: ../delete_poll.rb:112 ../poll.rb:340
 msgid "Delete"
-msgstr "Supprimer"
+msgstr "Kolímuisa"
 
 #: ../access_control.rb:121 ../customize.cgi:116 ../customize.rb:116
 #: ../poll.rb:302
 msgid "Save"
-msgstr "Enregistrer"
+msgstr "Kobómbisa"
 
 #: ../access_control.rb:139
 msgid "Only letters and digits are allowed in the username."
@@ -101,11 +101,11 @@ msgstr "Changer les règles de contrôle d'accès"
 
 #: ../access_control.rb:179
 msgid "not activated"
-msgstr "inactif"
+msgstr "na mosálá tɛ́"
 
 #: ../access_control.rb:181
 msgid "Activate"
-msgstr "Activer"
+msgstr "Kolamuisa"
 
 #: ../access_control.rb:184
 msgid "controls will be activated when at least the admin user is configured"
@@ -117,7 +117,7 @@ msgstr "Désactiver"
 
 #: ../access_control.rb:188
 msgid "activated"
-msgstr "activé"
+msgstr "elamúísámí"
 
 #: ../access_control.rb:189
 msgid ""
@@ -147,12 +147,12 @@ msgstr "L'utilisateur 'participant’ n'a accès qu'au vote."
 
 #: ../access_control.rb:208
 msgid "Access control:"
-msgstr "Contrôle d'accès :"
+msgstr "Bonɔ́ngi ya liyíngeli:"
 
 #: ../advanced.rb:31 ../advanced.rb:35
 #, fuzzy
 msgid "Revert poll"
-msgstr "Supprimer le sondage"
+msgstr "Kobakola sondage"
 
 #: ../advanced.rb:32
 #, fuzzy
@@ -168,7 +168,7 @@ msgstr ""
 #: ../advanced.rb:39
 #, fuzzy
 msgid "Revert"
-msgstr "Supprimer le sondage"
+msgstr "Kobakola sondage"
 
 #: ../authorization_required.cgi:36 ../authorization_required.cgi:52
 msgid "Authorization required"
@@ -197,7 +197,7 @@ msgstr "Vous devez vous identifier pour afficher cette page !"
 
 #: ../customize.cgi:31 ../customize.rb:31
 msgid "Customize personal settings"
-msgstr "Préférences"
+msgstr "Malúli"
 
 #: ../customize.cgi:32 ../customize.rb:32
 #, fuzzy
@@ -208,11 +208,11 @@ msgstr "Les cookies doivent être activés pour personnaliser vos préférences.
 
 #: ../customize.cgi:39 ../customize.rb:39
 msgid "Current setting"
-msgstr "Paramètres actuels"
+msgstr "Palamɛ́tɛlɛ na mosálá"
 
 #: ../customize.cgi:40 ../customize.rb:40
 msgid "Description"
-msgstr "Description"
+msgstr "Bolimboli"
 
 #: ../customize.cgi:57 ../customize.rb:57
 msgid "Use special characters"
@@ -233,19 +233,19 @@ msgstr ""
 
 #: ../customize.cgi:61 ../customize.rb:61
 msgid "Charset"
-msgstr "Charset"
+msgstr "Kɔdázɛ"
 
 #: ../customize.cgi:66 ../customize.rb:66
 msgid "Stylesheet"
-msgstr "Feuille de style"
+msgstr "Lonkásá lia stílɛ"
 
 #: ../customize.cgi:81 ../customize.rb:81
 msgid "Default Username"
-msgstr "Nom d'utilisateur par défaut"
+msgstr "Mosáleli ya lipɔneli"
 
 #: ../customize.cgi:106 ../customize.rb:106
 msgid "Edit"
-msgstr "Éditer"
+msgstr "Kobimisela"
 
 #: ../delete_poll.rb:30
 msgid "Yes, I know what I am doing!"
@@ -301,15 +301,15 @@ msgstr "Chercher quelque chose avec Google"
 
 #: ../delete_poll.rb:88
 msgid "To delete the poll, you have to type:"
-msgstr "Pour supprimer ce sondage, vous devez taper :"
+msgstr "Pour supprimer ce sondage, vous devez taper:"
 
 #: ../delete_poll.rb:96
 msgid "but you typed:"
-msgstr "mais vous avez tapé :"
+msgstr "mais vous avez tapé:"
 
 #: ../delete_poll.rb:108
 msgid "Delete this poll"
-msgstr "Supprimer ce sondage"
+msgstr "Kolímuisa sondage"
 
 #: ../delete_poll.rb:109
 msgid "You want to delete the poll named"
@@ -330,7 +330,7 @@ msgstr ""
 
 #: ../dudle.rb:73
 msgid "Home"
-msgstr "Accueil"
+msgstr "Lonkásá loa libosó"
 
 #: ../dudle.rb:76
 msgid "Poll"
@@ -338,11 +338,11 @@ msgstr "Sondage"
 
 #: ../dudle.rb:77 ../history.rb:35
 msgid "History"
-msgstr "Historique"
+msgstr "Mokóló"
 
 #: ../dudle.rb:80
 msgid "Edit Columns"
-msgstr "Éditer les colonnes"
+msgstr "Kobimisela lia likonzí"
 
 #: ../dudle.rb:81 ../invite_participants.rb:38
 msgid "Invite Participants"
@@ -354,11 +354,11 @@ msgstr "Droits d'accès"
 
 #: ../dudle.rb:83
 msgid "Overview"
-msgstr "Écraser"
+msgstr "xxxxx"
 
 #: ../dudle.rb:86
 msgid "Delete Poll"
-msgstr "Supprimer le sondage"
+msgstr "Kolímuisa sondage"
 
 #: ../dudle.rb:89 ../example.cgi:67
 msgid "Examples"
@@ -370,19 +370,19 @@ msgstr "À propos"
 
 #: ../dudle.rb:92
 msgid "Customize"
-msgstr "Personnaliser"
+msgstr "Bosekisi"
 
 #: ../dudle.rb:100
 msgid "DuD-Poll Home"
-msgstr "Accueil de DuD-Poll"
+msgstr "Libosó lia DuD-Poll"
 
 #: ../dudle.rb:208 ../dudle.rb:226
 msgid "Previous"
-msgstr "Précédent"
+msgstr "Lolekí"
 
 #: ../dudle.rb:209 ../dudle.rb:227
 msgid "Next"
-msgstr "Suivant"
+msgstr "Lolandí"
 
 #: ../dudle.rb:210 ../dudle.rb:228
 msgid "Finish"
@@ -394,12 +394,12 @@ msgstr "Toutes les modifications ont été sauvegardées."
 
 #: ../dudle.rb:233
 msgid "Proceed!"
-msgstr "Effectuer !"
+msgstr "Effectuer!"
 
 #: ../dudle.rb:282
 #, fuzzy
 msgid "Select Language"
-msgstr "Choisi"
+msgstr "Lokótá"
 
 #: ../edit_columns.rb:44
 msgid "Add and remove columns"
@@ -407,27 +407,27 @@ msgstr "Ajouter et supprimer des colonnes"
 
 #: ../edit_columns.rb:67 ../edit_columns.rb:86 ../timepollhead.rb:249
 msgid "Delete column"
-msgstr "Supprimer une colonne"
+msgstr "Kolímuisa likonzí"
 
 #: ../edit_columns.rb:69 ../edit_columns.rb:84 ../timepollhead.rb:248
 msgid "Add column"
-msgstr "Ajouter une colonne"
+msgstr "Kobakisa likonzí"
 
 #: ../edit_columns.rb:71 ../edit_columns.rb:88
 msgid "Edit column"
-msgstr "Éditer une colonne"
+msgstr "Kobimisela likonzí"
 
 #: ../edit_columns.rb:99
 msgid "Undo"
-msgstr "Annuler"
+msgstr "Kozóngela"
 
 #: ../edit_columns.rb:99
 msgid "Redo"
-msgstr "Répéter"
+msgstr "Kobandela"
 
 #: ../error.cgi:25 ../error.cgi:27
 msgid "Error"
-msgstr "Erreur"
+msgstr "Zíko"
 
 #: ../error.cgi:41
 msgid "The following error was printed:"
@@ -450,7 +450,7 @@ msgstr ""
 
 #: ../error.cgi:46
 msgid "Bug in DuD-Poll"
-msgstr "Bug dans DuD-Poll"
+msgstr "Zíko na DuD-Poll"
 
 #: ../error.cgi:48
 msgid ""
@@ -489,11 +489,11 @@ msgstr "Sondage courant (Version %{revisionnumber})"
 
 #: ../html.rb:131
 msgid "xml:lang='en' dir='ltr'"
-msgstr "xml:lang='fr' dir='ltr'"
+msgstr "xml:lang='ln' dir='ltr'"
 
 #: ../index.cgi:32
 msgid "Please enter a descriptive title."
-msgstr "Entrez un titre s'il-vous-plait."
+msgstr "Entrez un titre s'il-vous-plaît."
 
 #: ../index.cgi:43
 msgid "Custom address may only contain letters, numbers, and dashes."
@@ -550,15 +550,15 @@ msgstr "Créer"
 
 #: ../log.rb:111
 msgid "Version"
-msgstr "Version"
+msgstr "Libóngoli"
 
 #: ../log.rb:111
 msgid "Date"
-msgstr "Date"
+msgstr "Mokɔlɔ"
 
 #: ../log.rb:111
 msgid "Comment"
-msgstr "Commentaire"
+msgstr "Linanoli"
 
 #: ../maintenance.cgi:25 ../maintenance.cgi:27
 msgid "Maintenance"
@@ -605,15 +605,15 @@ msgstr ""
 
 #: ../overview.rb:31
 msgid "The next steps are:"
-msgstr "Les étapes suivantes sont : "
+msgstr "Les étapes suivantes sont: "
 
 #: ../overview.rb:33
 msgid "Send the link to all participants:"
-msgstr "Envoyer ce lien à tous les participants : "
+msgstr "Kotínda ekangisi-nkomá na tous les participants: "
 
 #: ../overview.rb:34
 msgid "Send this link via email..."
-msgstr "Envoyer ce lien par email..."
+msgstr "Kotínda ekangisi-nkomá na nkandá..."
 
 #: ../overview.rb:35
 msgid "Visit the poll yourself:"
@@ -621,7 +621,7 @@ msgstr "Aller sur le sondage : "
 
 #: ../overview.rb:36
 msgid "Link to DuD-Poll about %{polltitle}"
-msgstr "Lien vers le sondage DuD-Poll \"%{polltitle}\""
+msgstr "Ekangisi-nkomá vers le sondage DuD-Poll \"%{polltitle}\""
 
 #: ../participate.rb:59
 msgid "The changes were saved, you should be redirected to %{link}."
@@ -647,7 +647,7 @@ msgstr "Inviter"
 
 #: ../poll.rb:187 ../pollhead.rb:62 ../timepollhead.rb:158
 msgid "Name"
-msgstr "Nom"
+msgstr "Nkómbó"
 
 #: ../poll.rb:229
 #, fuzzy
@@ -660,7 +660,7 @@ msgstr "Enregistrer les modifications"
 
 #: ../poll.rb:237
 msgid "Cancel"
-msgstr "Annuler"
+msgstr "Kolímuisa"
 
 #: ../poll.rb:259
 msgid "Do you really want to delete user %{user}?"
@@ -668,23 +668,23 @@ msgstr "Voulez-vous réellement supprimer l'utilisateur %{user} ?"
 
 #: ../poll.rb:262
 msgid "Confirm"
-msgstr "Confirmer"
+msgstr "Kondima"
 
 #: ../poll.rb:283
 msgid "Yes"
-msgstr ""
+msgstr "Íyo"
 
 #: ../poll.rb:283
 msgid "No"
-msgstr ""
+msgstr "Tɛ́"
 
 #: ../poll.rb:283
 msgid "Maybe"
-msgstr ""
+msgstr "Sɔ́kɔ́"
 
 #: ../poll.rb:311
 msgid "Comments"
-msgstr "Commentaires"
+msgstr "Linanoli"
 
 #: ../poll.rb:314
 msgid "Sort oldest comment first"
@@ -749,17 +749,17 @@ msgstr "liés au contrôle d'accès"
 
 #: ../poll.rb:392
 msgid "Update"
-msgstr "Mettre à jour"
+msgstr "Kotía sika"
 
 #: ../pollhead.rb:71
 #, fuzzy
 msgid "Edit option"
-msgstr "Éditer une colonne"
+msgstr "Kobimisela likonzí"
 
 #: ../pollhead.rb:72
 #, fuzzy
 msgid "Delete option"
-msgstr "Supprimer une colonne"
+msgstr "Kolímuisa likonzí"
 
 #: ../pollhead.rb:87 ../timepollhead.rb:162
 msgid "Last edit"
@@ -777,11 +777,11 @@ msgstr "Description (optionnel)"
 #: ../pollhead.rb:101
 #, fuzzy
 msgid "Add/Edit option"
-msgstr "Ajouter/Éditer la colonne"
+msgstr "Kobakisa/Kobimisela likonzí"
 
 #: ../pollhead.rb:102
 msgid "Preview"
-msgstr "Prévisualiser"
+msgstr "Botáli"
 
 #: ../pollhead.rb:103
 msgid ""
@@ -818,7 +818,7 @@ msgstr "Cliquez sur les dates pour ajouter ou supprimer une colonne."
 
 #: ../timepollhead.rb:313
 msgid "Optional:"
-msgstr "Optionnel :"
+msgstr "Optionnel:"
 
 #: ../timepollhead.rb:314
 msgid "Select specific start times."
@@ -826,15 +826,15 @@ msgstr "Entrer une heure de début."
 
 #: ../timepollhead.rb:330
 msgid "Time"
-msgstr "Heure"
+msgstr "Ngonga"
 
 #: ../timepollhead.rb:343
 msgid "Selected"
-msgstr "Choisi"
+msgstr "Lipɔnisi"
 
 #: ../timepollhead.rb:344
 msgid "Not selected"
-msgstr "Non choisi"
+msgstr "Lipɔnisi tɛ́"
 
 #: ../timepollhead.rb:345
 msgid "Past"
@@ -850,7 +850,7 @@ msgstr "Déselectionner toute la ligne"
 
 #: ../timepollhead.rb:428
 msgid "Add"
-msgstr "Ajouter"
+msgstr "Kobakisa"
 
 #: ../timepollhead.rb:429
 msgid "e.&thinsp;g., 09:30, morning, afternoon"

--- a/locale/ln/dudle.po
+++ b/locale/ln/dudle.po
@@ -1,0 +1,903 @@
+# ######################################################################## #
+# Copyright 2011 Eric Seigne, Florent Fourcot, Gilles Seban                #
+#                                                                          #
+# This file is part of Dudle.                                              #
+#                                                                          #
+# Dudle is free software: you can redistribute it and/or modify it under   #
+# the terms of the GNU Affero General Public License as published by       #
+# the Free Software Foundation, either version 3 of the License, or        #
+# (at your option) any later version.                                      #
+#                                                                          #
+# Dudle is distributed in the hope that it will be useful, but WITHOUT ANY #
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or        #
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public     #
+# License for more details.                                                #
+#                                                                          #
+# You should have received a copy of the GNU Affero General Public License #
+# along with dudle.  If not, see <http://www.gnu.org/licenses/>.           #
+# ######################################################################## #
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-05-04 22:19+0200\n"
+"PO-Revision-Date: 2019-02-25 16:57+0100\n"
+"Last-Translator: Séb. M.\n"
+"Language-Team: \n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Poedit-Basepath: ../../\n"
+"X-Poedit-Language: Lingala\n"
+"X-Poedit-Country: CONGO\n"
+"X-Dudle-Language: Lingála\n"
+"X-Poedit-SearchPath-0: .\n"
+
+#: ../about.cgi:29
+msgid "This application is powered by %{DuDPoll}."
+msgstr "Application soutenue par %{DuDPoll}."
+
+#: ../about.cgi:31
+msgid "License"
+msgstr "License"
+
+#: ../about.cgi:32
+msgid ""
+"The sourcecode of this application is available under the terms of <a "
+"href='http://www.fsf.org/licensing/licenses/agpl-3.0.html'>AGPL Version 3</"
+"a>."
+msgstr ""
+"Le code source de cette application est disponible sous le contrat de "
+"licence <a href='http://www.fsf.org/licensing/licenses/agpl-3.0."
+"html'>AGPLv3</a>."
+
+#: ../about.cgi:33
+msgid "The sourcecode of this application can be found %{a_start}here%{a_end}."
+msgstr "Le code source de l'application est disponible %{a_start}ici%{a_end}."
+
+#: ../access_control.rb:74 ../customize.cgi:82 ../customize.rb:82
+msgid "Username:"
+msgstr "Identifiant :"
+
+#: ../access_control.rb:87
+msgid "Password"
+msgstr "Mot de passe"
+
+#: ../access_control.rb:88
+msgid "repeat"
+msgstr "répéter"
+
+#: ../access_control.rb:114
+msgid ""
+"You have to remove the participant user before you can remove the "
+"administrator."
+msgstr ""
+"Vous devez supprimer les utilisateurs participants avant de pouvoir "
+"supprimer l'administrateur."
+
+#: ../access_control.rb:117 ../customize.cgi:119 ../customize.rb:119
+#: ../delete_poll.rb:112 ../poll.rb:340
+msgid "Delete"
+msgstr "Supprimer"
+
+#: ../access_control.rb:121 ../customize.cgi:116 ../customize.rb:116
+#: ../poll.rb:302
+msgid "Save"
+msgstr "Enregistrer"
+
+#: ../access_control.rb:139
+msgid "Only letters and digits are allowed in the username."
+msgstr ""
+"Seuls les lettres et chiffres sont autorisés dans les noms d'utilisateurs."
+
+#: ../access_control.rb:141
+msgid "Passwords did not match."
+msgstr "Mot de passe incorrect."
+
+#: ../access_control.rb:175
+msgid "Change access control settings"
+msgstr "Changer les règles de contrôle d'accès"
+
+#: ../access_control.rb:179
+msgid "not activated"
+msgstr "inactif"
+
+#: ../access_control.rb:181
+msgid "Activate"
+msgstr "Activer"
+
+#: ../access_control.rb:184
+msgid "controls will be activated when at least the admin user is configured"
+msgstr "sera activé dès qu'un administrateur aura été configuré"
+
+#: ../access_control.rb:186
+msgid "Deactivate"
+msgstr "Désactiver"
+
+#: ../access_control.rb:188
+msgid "activated"
+msgstr "activé"
+
+#: ../access_control.rb:189
+msgid ""
+"You have to remove all users before you can deactivate the access control "
+"settings."
+msgstr ""
+"Vous devez supprimer tous les utilisateurs avant de pouvoir désactiver le "
+"contrôle d'accès."
+
+#: ../access_control.rb:193
+msgid ""
+"You will be asked for the password you have entered here after you press "
+"save!"
+msgstr ""
+"Le mot de passe tapé vous sera demandé après avoir cliqué sur Sauvegarder !"
+
+#: ../access_control.rb:196
+#, fuzzy
+msgid ""
+"The user ‘admin’ has access to both the vote and the configuration interface."
+msgstr ""
+"L'utilisateur 'admin' a accès au vote ainsi qu'au panneau de configuration."
+
+#: ../access_control.rb:202
+msgid "The user ‘participant’ only has access to the vote interface."
+msgstr "L'utilisateur 'participant’ n'a accès qu'au vote."
+
+#: ../access_control.rb:208
+msgid "Access control:"
+msgstr "Contrôle d'accès :"
+
+#: ../advanced.rb:31 ../advanced.rb:35
+#, fuzzy
+msgid "Revert poll"
+msgstr "Supprimer le sondage"
+
+#: ../advanced.rb:32
+#, fuzzy
+msgid "Poll was reverted to Version %{version}!"
+msgstr "Sondage courant (Version %{revisionnumber})"
+
+#: ../advanced.rb:37
+msgid "Revert poll to version (see ‘History’ tab for revision numbers): "
+msgstr ""
+"Retourner à la version de sondage (voir l'onglet « Historique » pour les "
+"numéros de révision) :"
+
+#: ../advanced.rb:39
+#, fuzzy
+msgid "Revert"
+msgstr "Supprimer le sondage"
+
+#: ../authorization_required.cgi:36 ../authorization_required.cgi:52
+msgid "Authorization required"
+msgstr "Autorisation requise"
+
+#: ../authorization_required.cgi:39
+msgid "The configuration of this poll is password-protected!"
+msgstr "La configuration de ce sondage est protégée par un mot de passe !"
+
+#: ../authorization_required.cgi:41
+msgid "This poll is password-protected!"
+msgstr "Ce sondage est protégé par un mot de passe !"
+
+#: ../authorization_required.cgi:43
+msgid "In order to proceed, you have to give the password for user %{user}."
+msgstr ""
+"Vous devez vous identifier avec l'identifiant %{user} avant de continuer."
+
+#: ../authorization_required.cgi:53 ../not_found.cgi:36
+msgid "Return to DuD-Poll home and schedule a new poll"
+msgstr "Retourner à la page d'acceuil et créer un nouveau sondage"
+
+#: ../authorization_required.cgi:54
+msgid "You have to authorize yourself in order to access this page!"
+msgstr "Vous devez vous identifier pour afficher cette page !"
+
+#: ../customize.cgi:31 ../customize.rb:31
+msgid "Customize personal settings"
+msgstr "Préférences"
+
+#: ../customize.cgi:32 ../customize.rb:32
+#, fuzzy
+msgid ""
+"You need <a href='https://en.wikipedia.org/wiki/HTTP_cookie'>cookies</a> "
+"enabled in order to personalize your settings."
+msgstr "Les cookies doivent être activés pour personnaliser vos préférences."
+
+#: ../customize.cgi:39 ../customize.rb:39
+msgid "Current setting"
+msgstr "Paramètres actuels"
+
+#: ../customize.cgi:40 ../customize.rb:40
+msgid "Description"
+msgstr "Description"
+
+#: ../customize.cgi:57 ../customize.rb:57
+msgid "Use special characters"
+msgstr "Utiliser des caractères spéciaux"
+
+#: ../customize.cgi:57 ../customize.rb:57
+msgid "Use this option if you see the characters in the parenthesis."
+msgstr "Utilisez cette option si vous voyez les caractères entre parenthèses."
+
+#: ../customize.cgi:58 ../customize.rb:58
+msgid "Use only normal strings"
+msgstr "Utiliser uniquement des caractères normaux"
+
+#: ../customize.cgi:58 ../customize.rb:58
+msgid "Use this option if you have problems with some characters."
+msgstr ""
+"Utilisez cette option si vous avez des problèmes avec certains caractères."
+
+#: ../customize.cgi:61 ../customize.rb:61
+msgid "Charset"
+msgstr "Charset"
+
+#: ../customize.cgi:66 ../customize.rb:66
+msgid "Stylesheet"
+msgstr "Feuille de style"
+
+#: ../customize.cgi:81 ../customize.rb:81
+msgid "Default Username"
+msgstr "Nom d'utilisateur par défaut"
+
+#: ../customize.cgi:106 ../customize.rb:106
+msgid "Edit"
+msgstr "Éditer"
+
+#: ../delete_poll.rb:30
+msgid "Yes, I know what I am doing!"
+msgstr "Oui, je sais ce que je fais !"
+
+#: ../delete_poll.rb:31
+msgid "I hate these stupid entry fields."
+msgstr "Je hais ces entrées de formulaires idiotes."
+
+#: ../delete_poll.rb:32
+msgid "I am aware of the consequences."
+msgstr "Je suis conscient des conséquences de mes actes."
+
+#: ../delete_poll.rb:33
+msgid "Please delete this poll."
+msgstr "Supprimez ce sondage."
+
+#: ../delete_poll.rb:42
+msgid "Example polls cannot be deleted."
+msgstr "Les sondages en exemple ne peuvent pas être supprimé."
+
+#: ../delete_poll.rb:43
+msgid "You should never see this text."
+msgstr "Vous ne devriez jamais voir ce text."
+
+#: ../delete_poll.rb:56
+msgid "The poll was deleted successfully!"
+msgstr "Ce sondage a été supprimé !"
+
+#: ../delete_poll.rb:57
+#, fuzzy
+msgid ""
+"If this was done by accident, please contact the administrator of the "
+"system. The poll can be recovered for an indeterminate amount of time; it "
+"could already be too late."
+msgstr ""
+"Si cela a été fait par accident, merci de prendre contact avec "
+"l'administrateur du système. Votre sondage peut-être restauré durant une "
+"durée indeterminée, peut-être est-il déjà trop tard."
+
+#: ../delete_poll.rb:59
+msgid "You can now"
+msgstr "Vous pouvez maintenant"
+
+#: ../delete_poll.rb:61
+msgid "Browse Wikipedia"
+msgstr "Naviguer sur Wikipédia"
+
+#: ../delete_poll.rb:62
+#, fuzzy
+msgid "Search for something on the Internet"
+msgstr "Chercher quelque chose avec Google"
+
+#: ../delete_poll.rb:88
+msgid "To delete the poll, you have to type:"
+msgstr "Pour supprimer ce sondage, vous devez taper :"
+
+#: ../delete_poll.rb:96
+msgid "but you typed:"
+msgstr "mais vous avez tapé :"
+
+#: ../delete_poll.rb:108
+msgid "Delete this poll"
+msgstr "Supprimer ce sondage"
+
+#: ../delete_poll.rb:109
+msgid "You want to delete the poll named"
+msgstr "Vous voulez supprimez le sondage nommé"
+
+#: ../delete_poll.rb:110
+msgid "This is an irreversible action!"
+msgstr "C'est une action irréversible !"
+
+#: ../delete_poll.rb:111
+#, fuzzy
+msgid ""
+"If you are sure that you want to permanently remove this poll, please type "
+"“%{question}” into the form."
+msgstr ""
+"Si vous êtes certains de ce que vous faites, tapez \"%{question}\" dans le "
+"formulaire."
+
+#: ../dudle.rb:73
+msgid "Home"
+msgstr "Accueil"
+
+#: ../dudle.rb:76
+msgid "Poll"
+msgstr "Sondage"
+
+#: ../dudle.rb:77 ../history.rb:35
+msgid "History"
+msgstr "Historique"
+
+#: ../dudle.rb:80
+msgid "Edit Columns"
+msgstr "Éditer les colonnes"
+
+#: ../dudle.rb:81 ../invite_participants.rb:38
+msgid "Invite Participants"
+msgstr "Inviter des participants"
+
+#: ../dudle.rb:82
+msgid "Access Control"
+msgstr "Droits d'accès"
+
+#: ../dudle.rb:83
+msgid "Overview"
+msgstr "Écraser"
+
+#: ../dudle.rb:86
+msgid "Delete Poll"
+msgstr "Supprimer le sondage"
+
+#: ../dudle.rb:89 ../example.cgi:67
+msgid "Examples"
+msgstr "Exemples"
+
+#: ../dudle.rb:90
+msgid "About"
+msgstr "À propos"
+
+#: ../dudle.rb:92
+msgid "Customize"
+msgstr "Personnaliser"
+
+#: ../dudle.rb:100
+msgid "DuD-Poll Home"
+msgstr "Accueil de DuD-Poll"
+
+#: ../dudle.rb:208 ../dudle.rb:226
+msgid "Previous"
+msgstr "Précédent"
+
+#: ../dudle.rb:209 ../dudle.rb:227
+msgid "Next"
+msgstr "Suivant"
+
+#: ../dudle.rb:210 ../dudle.rb:228
+msgid "Finish"
+msgstr "Fin"
+
+#: ../dudle.rb:233
+msgid "All changes were saved successfully."
+msgstr "Toutes les modifications ont été sauvegardées."
+
+#: ../dudle.rb:233
+msgid "Proceed!"
+msgstr "Effectuer !"
+
+#: ../dudle.rb:282
+#, fuzzy
+msgid "Select Language"
+msgstr "Choisi"
+
+#: ../edit_columns.rb:44
+msgid "Add and remove columns"
+msgstr "Ajouter et supprimer des colonnes"
+
+#: ../edit_columns.rb:67 ../edit_columns.rb:86 ../timepollhead.rb:249
+msgid "Delete column"
+msgstr "Supprimer une colonne"
+
+#: ../edit_columns.rb:69 ../edit_columns.rb:84 ../timepollhead.rb:248
+msgid "Add column"
+msgstr "Ajouter une colonne"
+
+#: ../edit_columns.rb:71 ../edit_columns.rb:88
+msgid "Edit column"
+msgstr "Éditer une colonne"
+
+#: ../edit_columns.rb:99
+msgid "Undo"
+msgstr "Annuler"
+
+#: ../edit_columns.rb:99
+msgid "Redo"
+msgstr "Répéter"
+
+#: ../error.cgi:25 ../error.cgi:27
+msgid "Error"
+msgstr "Erreur"
+
+#: ../error.cgi:41
+msgid "The following error was printed:"
+msgstr "L'erreur suivante a été affichée :"
+
+#: ../error.cgi:45
+msgid ""
+"Hi!\n"
+"\n"
+"I found a bug in your application at %{urlofsite}.\n"
+"I did the following:\n"
+"\n"
+"<please describe what you did>\n"
+"<e.g., I wanted to post a comment to the poll.>\n"
+"\n"
+"I am using <please state your browser and operating system>\n"
+"%{errormessage}\n"
+"Sincerely,\n"
+msgstr ""
+
+#: ../error.cgi:46
+msgid "Bug in DuD-Poll"
+msgstr "Bug dans DuD-Poll"
+
+#: ../error.cgi:48
+msgid ""
+"An error occurred while executing DuD-Poll.<br/>Please send an error report, "
+"including your browser, operating system, and what you did to %{admin}."
+msgstr ""
+"Une erreur s'est produite durant l'exécution de DuD-Poll.<br/>Merci d'envoyer "
+"une description de l'erreur, contenant votre navigateur, votre système "
+"d'exploitation, et ce que vous avez fait à %{admin} (de préférence en "
+"anglais ou en allemand)."
+
+#: ../error.cgi:51
+msgid "Please include the following as well:"
+msgstr "Veuillez inclure ce qui suit :"
+
+#: ../example.cgi:60
+msgid "Example not found: %{example}"
+msgstr ""
+
+#: ../example.cgi:68
+msgid ""
+"If you want to play with the application, you may want to take a look at "
+"these example polls:"
+msgstr ""
+"Si vous voulez utiliser l'application, vous pouvez être intéressé par ces "
+"exemples de sondages :"
+
+#: ../history.rb:28
+#, fuzzy
+msgid "Poll of version %{revisionnumber}"
+msgstr "Sondage courant (Version %{revisionnumber})"
+
+#: ../history.rb:32
+msgid "Current poll (version %{revisionnumber})"
+msgstr "Sondage courant (Version %{revisionnumber})"
+
+#: ../html.rb:131
+msgid "xml:lang='en' dir='ltr'"
+msgstr "xml:lang='fr' dir='ltr'"
+
+#: ../index.cgi:32
+msgid "Please enter a descriptive title."
+msgstr "Entrez un titre s'il-vous-plait."
+
+#: ../index.cgi:43
+msgid "Custom address may only contain letters, numbers, and dashes."
+msgstr ""
+"Les adresses personnalisées ne peuvent contenir que des lettres, chiffres et "
+"tirets"
+
+#: ../index.cgi:45
+msgid "A poll with this address already exists."
+msgstr "Un sondage ayant cette adresse existe déjà."
+
+#: ../index.cgi:63
+msgid ""
+"The poll was created successfully. The link to your new poll is: %{link}"
+msgstr ""
+"Le sondage a été créé avec succès. Le lien vers votre nouveau sondage "
+"est : %{link}"
+
+#: ../index.cgi:71
+msgid "Go away."
+msgstr "Fuyez."
+
+#: ../index.cgi:79
+msgid "Create new poll"
+msgstr "Créer un nouveau sondage"
+
+#: ../index.cgi:81
+msgid "Title"
+msgstr "Titre"
+
+#: ../index.cgi:82
+msgid "Type"
+msgstr "Type"
+
+#: ../index.cgi:83
+msgid "Event-scheduling poll (e.&thinsp;g., schedule a meeting)"
+msgstr "Sondage \"agenda\" (ex. prévoir une réunion)"
+
+#: ../index.cgi:84
+msgid "Normal poll (e.&thinsp;g., vote for what is the best coffee)"
+msgstr "Sondage normal (par exemple un vote pour le choix du meilleur café)"
+
+#: ../index.cgi:85
+msgid "Custom address (optional)"
+msgstr "Adresse personnalisée (optionnel)"
+
+#: ../index.cgi:86
+msgid "May contain letters, numbers, and dashes."
+msgstr "Peut contenir des lettres, chiffres et tirets."
+
+#: ../index.cgi:88
+msgid "Create"
+msgstr "Créer"
+
+#: ../log.rb:111
+msgid "Version"
+msgstr "Version"
+
+#: ../log.rb:111
+msgid "Date"
+msgstr "Date"
+
+#: ../log.rb:111
+msgid "Comment"
+msgstr "Commentaire"
+
+#: ../maintenance.cgi:25 ../maintenance.cgi:27
+msgid "Maintenance"
+msgstr ""
+
+#: ../maintenance.cgi:31
+msgid "This site is currently undergoing maintenance!"
+msgstr "Ce site est en maintenance en ce moment !"
+
+#: ../maintenance.cgi:34
+msgid ""
+"You should not browse to this file directly. Please create a file named "
+"\"maintenance.html\" to enable the maintenance mode."
+msgstr ""
+"Vous ne devez pas parcourir les dossiers directement. Veuillez créer un "
+"fichier \"maintenance.html\" pour activer le mode maintenance."
+
+#: ../not_found.cgi:30
+msgid "Poll not found"
+msgstr "Sondage introuvable"
+
+#: ../not_found.cgi:32
+msgid "The requested poll was not found."
+msgstr "Le sondage demandé est introuvable."
+
+#: ../not_found.cgi:33
+msgid "There are several reasons why a poll may have been deleted:"
+msgstr "Il peut y avoir plusieurs explications à la suppression d'un sondage :"
+
+#: ../not_found.cgi:34
+msgid "Somebody clicked on “Delete poll” and deleted the poll manually."
+msgstr ""
+"Quelqu'un a cliqué sur \"Supprimer le sondage\" et supprimé le sondage "
+"manuellement."
+
+#: ../not_found.cgi:35
+#, fuzzy
+msgid ""
+"The poll was deleted by the administrator because it was not accessed for a "
+"long time."
+msgstr ""
+"Le sondage a été supprimé par l'administrateur car il était inactif depuis "
+"une longue période."
+
+#: ../overview.rb:31
+msgid "The next steps are:"
+msgstr "Les étapes suivantes sont : "
+
+#: ../overview.rb:33
+msgid "Send the link to all participants:"
+msgstr "Envoyer ce lien à tous les participants : "
+
+#: ../overview.rb:34
+msgid "Send this link via email..."
+msgstr "Envoyer ce lien par email..."
+
+#: ../overview.rb:35
+msgid "Visit the poll yourself:"
+msgstr "Aller sur le sondage : "
+
+#: ../overview.rb:36
+msgid "Link to DuD-Poll about %{polltitle}"
+msgstr "Lien vers le sondage DuD-Poll \"%{polltitle}\""
+
+#: ../participate.rb:59
+msgid "The changes were saved, you should be redirected to %{link}."
+msgstr ""
+"Les modifications ont été sauvegardées, vous devriez être redirigé vers "
+"%{link}."
+
+#: ../poll.rb:96
+msgid "Edit user %{user}..."
+msgstr "Éditer l'utilisateur %{user}..."
+
+#: ../poll.rb:100
+msgid "Delete user %{user}..."
+msgstr "Supprimer l'utilisateur %{user}"
+
+#: ../poll.rb:154
+msgid "Total"
+msgstr "Total"
+
+#: ../poll.rb:186
+msgid "Invite"
+msgstr "Inviter"
+
+#: ../poll.rb:187 ../pollhead.rb:62 ../timepollhead.rb:158
+msgid "Name"
+msgstr "Nom"
+
+#: ../poll.rb:229
+#, fuzzy
+msgid "Add a participant"
+msgstr "Inviter des participants"
+
+#: ../poll.rb:233
+msgid "Save changes"
+msgstr "Enregistrer les modifications"
+
+#: ../poll.rb:237
+msgid "Cancel"
+msgstr "Annuler"
+
+#: ../poll.rb:259
+msgid "Do you really want to delete user %{user}?"
+msgstr "Voulez-vous réellement supprimer l'utilisateur %{user} ?"
+
+#: ../poll.rb:262
+msgid "Confirm"
+msgstr "Confirmer"
+
+#: ../poll.rb:283
+msgid "Yes"
+msgstr ""
+
+#: ../poll.rb:283
+msgid "No"
+msgstr ""
+
+#: ../poll.rb:283
+msgid "Maybe"
+msgstr ""
+
+#: ../poll.rb:311
+msgid "Comments"
+msgstr "Commentaires"
+
+#: ../poll.rb:314
+msgid "Sort oldest comment first"
+msgstr "Afficher les commentaires les plus anciens en premier"
+
+#: ../poll.rb:317
+msgid "Sort newest comment first"
+msgstr "Afficher les commentaires les plus récents en premier"
+
+#: ../poll.rb:322
+msgid "Go to last comment"
+msgstr "Aller au dernier commentaire"
+
+#: ../poll.rb:335
+msgid "%{user} said on %{time}"
+msgstr "%{user} a dit à %{time}"
+
+#: ../poll.rb:350
+msgid "Go up"
+msgstr "Vers le haut"
+
+#: ../poll.rb:356
+msgid "says"
+msgstr "dit"
+
+#: ../poll.rb:357
+msgid "Submit comment"
+msgstr "Sauvegarder le commentaire"
+
+#: ../poll.rb:361
+msgid "Enter your name"
+msgstr ""
+
+#: ../poll.rb:363
+#, fuzzy
+msgid "Enter a comment"
+msgstr "Aller au dernier commentaire"
+
+#: ../poll.rb:375
+msgid "Show history items:"
+msgstr "Montrer les éléments de l'historique : "
+
+#: ../poll.rb:382
+msgid "All"
+msgstr "Tous"
+
+#: ../poll.rb:383
+msgid "Participant related"
+msgstr "liés aux participants"
+
+#: ../poll.rb:384
+msgid "Column related"
+msgstr "liés aux colonnes"
+
+#: ../poll.rb:385
+msgid "Comment related"
+msgstr "liés aux commentaires"
+
+#: ../poll.rb:386
+msgid "Access control related"
+msgstr "liés au contrôle d'accès"
+
+#: ../poll.rb:392
+msgid "Update"
+msgstr "Mettre à jour"
+
+#: ../pollhead.rb:71
+#, fuzzy
+msgid "Edit option"
+msgstr "Éditer une colonne"
+
+#: ../pollhead.rb:72
+#, fuzzy
+msgid "Delete option"
+msgstr "Supprimer une colonne"
+
+#: ../pollhead.rb:87 ../timepollhead.rb:162
+msgid "Last edit"
+msgstr "Dernière édition"
+
+#: ../pollhead.rb:99
+#, fuzzy
+msgid "Option"
+msgstr "Optionnel :"
+
+#: ../pollhead.rb:100
+msgid "Description (optional)"
+msgstr "Description (optionnel)"
+
+#: ../pollhead.rb:101
+#, fuzzy
+msgid "Add/Edit option"
+msgstr "Ajouter/Éditer la colonne"
+
+#: ../pollhead.rb:102
+msgid "Preview"
+msgstr "Prévisualiser"
+
+#: ../pollhead.rb:103
+msgid ""
+"Enter all the options (columns) which you want the participants of the poll "
+"to choose among. For each option you give here, the participants will choose "
+"a vote."
+msgstr ""
+"Entrer toutes les options (colonnes) que pourront choisir les participants "
+"du sondage. Les participant pourront voter pour chaque option proposée ici. "
+
+#: ../timepollhead.rb:113
+msgid ""
+"To add a time other than the default times, please enter some string here (e."
+"&thinsp;g., 09:30, morning, afternoon)."
+msgstr ""
+"Pour ajouter une heure différente de celles par défaut, veuiller ajouter une "
+"chaine de caractère ici (e.&thinsp;g., 09h30, matin, aprèm')."
+
+#: ../timepollhead.rb:119
+msgid "This time has already been selected."
+msgstr "Cette heure est déjà choisie."
+
+#: ../timepollhead.rb:193
+msgid "Earlier"
+msgstr "Plus tôt"
+
+#: ../timepollhead.rb:198
+msgid "Later"
+msgstr "Plus tard"
+
+#: ../timepollhead.rb:265
+msgid "Click on the dates to add or remove columns."
+msgstr "Cliquez sur les dates pour ajouter ou supprimer une colonne."
+
+#: ../timepollhead.rb:313
+msgid "Optional:"
+msgstr "Optionnel :"
+
+#: ../timepollhead.rb:314
+msgid "Select specific start times."
+msgstr "Entrer une heure de début."
+
+#: ../timepollhead.rb:330
+msgid "Time"
+msgstr "Heure"
+
+#: ../timepollhead.rb:343
+msgid "Selected"
+msgstr "Choisi"
+
+#: ../timepollhead.rb:344
+msgid "Not selected"
+msgstr "Non choisi"
+
+#: ../timepollhead.rb:345
+msgid "Past"
+msgstr "Passé"
+
+#: ../timepollhead.rb:379
+msgid "Select the whole row"
+msgstr "Sélectionner toute la ligne"
+
+#: ../timepollhead.rb:384
+msgid "Deselect the whole row"
+msgstr "Déselectionner toute la ligne"
+
+#: ../timepollhead.rb:428
+msgid "Add"
+msgstr "Ajouter"
+
+#: ../timepollhead.rb:429
+msgid "e.&thinsp;g., 09:30, morning, afternoon"
+msgstr "ex : 09h30, matin, après-midi"
+
+#, fuzzy
+#~ msgid ""
+#~ "Please write me an e-mail if you have found a bug, have found something "
+#~ "which disturbs you, or have any other feedback."
+#~ msgstr ""
+#~ "Si vous trouvez un bug ou un truc qui vous dérange, indiquez-le moi (de "
+#~ "préférence en anglais ou allemand) : <a href=\"mailto:"
+#~ "Benjamin_dot_Kellermann@gmx_in_deutschland?subject=Dudle%20Feedback"
+#~ "\">Feedback</a>"
+
+#, fuzzy
+#~ msgid ""
+#~ "If you think that the deletion was done in error, please contact the "
+#~ "administrator of the system."
+#~ msgstr ""
+#~ "Si vous pensez que la suppression est une erreur, merci de contacter "
+#~ "l'administrateur du système."
+
+#~ msgid "Event-scheduling poll"
+#~ msgstr "Sondage de choix de date"
+
+#~ msgid "Normal poll"
+#~ msgstr "Sondage normal"
+
+#~ msgid "Things you can do now are"
+#~ msgstr "Choses que vous pouvez faire maintenant"
+
+#~ msgid "--verbose"
+#~ msgstr "--verbose"
+
+#~ msgid ""
+#~ "You can get the sourcecode, using <a href='http://bazaar-vcs."
+#~ "org/'>bazaar</a>:"
+#~ msgstr ""
+#~ "Vous pouvez télécharger le code source à l'aide de <a href='http://bazaar-"
+#~ "vcs.org/'>bazaar</a>:"
+
+#~ msgid "The link to your poll is:"
+#~ msgstr "Le lien de votre sondage est :"
+
+#~ msgid "To the Vote interface"
+#~ msgstr "Vers la page de vote"
+
+#~ msgid "Alternative"
+#~ msgstr "Alternative"

--- a/locale/ln/dudle.po
+++ b/locale/ln/dudle.po
@@ -22,9 +22,9 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-05-04 22:19+0200\n"
 "PO-Revision-Date: 2019-02-25 16:57+0100\n"
-"Last-Translator: Séb. M.\n"
-"Language-Team: \n"
-"Language: \n"
+"Last-Translator: L10N\n"
+"Language-Team: ln\n"
+"Language: ln\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -93,7 +93,7 @@ msgstr ""
 
 #: ../access_control.rb:141
 msgid "Passwords did not match."
-msgstr "Mot de passe incorrect."
+msgstr "Banda ezalí malámu tɛ́."
 
 #: ../access_control.rb:175
 msgid "Change access control settings"
@@ -113,7 +113,7 @@ msgstr "sera activé dès qu'un administrateur aura été configuré"
 
 #: ../access_control.rb:186
 msgid "Deactivate"
-msgstr "Désactiver"
+msgstr "Kotendisa"
 
 #: ../access_control.rb:188
 msgid "activated"
@@ -132,7 +132,7 @@ msgid ""
 "You will be asked for the password you have entered here after you press "
 "save!"
 msgstr ""
-"Le mot de passe tapé vous sera demandé après avoir cliqué sur Sauvegarder !"
+"Le mot de passe tapé vous sera demandé après avoir cliqué sur Sauvegarder!"
 
 #: ../access_control.rb:196
 #, fuzzy
@@ -152,23 +152,23 @@ msgstr "Bonɔ́ngi ya liyíngeli:"
 #: ../advanced.rb:31 ../advanced.rb:35
 #, fuzzy
 msgid "Revert poll"
-msgstr "Kobakola sondage"
+msgstr "Kobakola litúnele"
 
 #: ../advanced.rb:32
 #, fuzzy
 msgid "Poll was reverted to Version %{version}!"
-msgstr "Sondage courant (Version %{revisionnumber})"
+msgstr "Litúnele courant (Version %{revisionnumber})"
 
 #: ../advanced.rb:37
 msgid "Revert poll to version (see ‘History’ tab for revision numbers): "
 msgstr ""
-"Retourner à la version de sondage (voir l'onglet « Historique » pour les "
+"Retourner à la version de litúnele (voir l'onglet « Historique » pour les "
 "numéros de révision) :"
 
 #: ../advanced.rb:39
 #, fuzzy
 msgid "Revert"
-msgstr "Kobakola sondage"
+msgstr "Kobakola litúnele"
 
 #: ../authorization_required.cgi:36 ../authorization_required.cgi:52
 msgid "Authorization required"
@@ -180,7 +180,7 @@ msgstr "La configuration de ce sondage est protégée par un mot de passe !"
 
 #: ../authorization_required.cgi:41
 msgid "This poll is password-protected!"
-msgstr "Ce sondage est protégé par un mot de passe !"
+msgstr "Ce litúnele est protégé par banda!"
 
 #: ../authorization_required.cgi:43
 msgid "In order to proceed, you have to give the password for user %{user}."
@@ -261,7 +261,7 @@ msgstr "Je suis conscient des conséquences de mes actes."
 
 #: ../delete_poll.rb:33
 msgid "Please delete this poll."
-msgstr "Supprimez ce sondage."
+msgstr "Supprimez ce litúnele."
 
 #: ../delete_poll.rb:42
 msgid "Example polls cannot be deleted."
@@ -273,7 +273,7 @@ msgstr "Vous ne devriez jamais voir ce text."
 
 #: ../delete_poll.rb:56
 msgid "The poll was deleted successfully!"
-msgstr "Ce sondage a été supprimé !"
+msgstr "Ce litúnele ezalí supprimé !"
 
 #: ../delete_poll.rb:57
 #, fuzzy
@@ -309,7 +309,7 @@ msgstr "mais vous avez tapé:"
 
 #: ../delete_poll.rb:108
 msgid "Delete this poll"
-msgstr "Kolímuisa sondage"
+msgstr "Kolímuisa litúnele"
 
 #: ../delete_poll.rb:109
 msgid "You want to delete the poll named"
@@ -334,7 +334,7 @@ msgstr "Lonkásá loa libosó"
 
 #: ../dudle.rb:76
 msgid "Poll"
-msgstr "Sondage"
+msgstr "Litúnele"
 
 #: ../dudle.rb:77 ../history.rb:35
 msgid "History"
@@ -358,7 +358,7 @@ msgstr "xxxxx"
 
 #: ../dudle.rb:86
 msgid "Delete Poll"
-msgstr "Kolímuisa sondage"
+msgstr "Kolímuisa litúnele"
 
 #: ../dudle.rb:89 ../example.cgi:67
 msgid "Examples"
@@ -476,16 +476,16 @@ msgid ""
 "these example polls:"
 msgstr ""
 "Si vous voulez utiliser l'application, vous pouvez être intéressé par ces "
-"exemples de sondages :"
+"exemples de sondages:"
 
 #: ../history.rb:28
 #, fuzzy
 msgid "Poll of version %{revisionnumber}"
-msgstr "Sondage courant (Version %{revisionnumber})"
+msgstr "Litúnele courant (Version %{revisionnumber})"
 
 #: ../history.rb:32
 msgid "Current poll (version %{revisionnumber})"
-msgstr "Sondage courant (Version %{revisionnumber})"
+msgstr "Litúnele courant (Version %{revisionnumber})"
 
 #: ../html.rb:131
 msgid "xml:lang='en' dir='ltr'"
@@ -518,23 +518,23 @@ msgstr "Fuyez."
 
 #: ../index.cgi:79
 msgid "Create new poll"
-msgstr "Créer un nouveau sondage"
+msgstr "Kokela litúnele lia síka"
 
 #: ../index.cgi:81
 msgid "Title"
-msgstr "Titre"
+msgstr "Litɛ́mɛ"
 
 #: ../index.cgi:82
 msgid "Type"
-msgstr "Type"
+msgstr "Típɛ"
 
 #: ../index.cgi:83
 msgid "Event-scheduling poll (e.&thinsp;g., schedule a meeting)"
-msgstr "Sondage \"agenda\" (ex. prévoir une réunion)"
+msgstr "Litúnele \"agenda\" (ex. prévoir une réunion)"
 
 #: ../index.cgi:84
 msgid "Normal poll (e.&thinsp;g., vote for what is the best coffee)"
-msgstr "Sondage normal (par exemple un vote pour le choix du meilleur café)"
+msgstr "Litúnele-kásá (par exemple un vote pour le choix du meilleur café)"
 
 #: ../index.cgi:85
 msgid "Custom address (optional)"
@@ -546,7 +546,7 @@ msgstr "Peut contenir des lettres, chiffres et tirets."
 
 #: ../index.cgi:88
 msgid "Create"
-msgstr "Créer"
+msgstr "Kokela"
 
 #: ../log.rb:111
 msgid "Version"
@@ -562,7 +562,7 @@ msgstr "Linanoli"
 
 #: ../maintenance.cgi:25 ../maintenance.cgi:27
 msgid "Maintenance"
-msgstr ""
+msgstr "Bobátɛli"
 
 #: ../maintenance.cgi:31
 msgid "This site is currently undergoing maintenance!"
@@ -578,15 +578,15 @@ msgstr ""
 
 #: ../not_found.cgi:30
 msgid "Poll not found"
-msgstr "Sondage introuvable"
+msgstr "Litúnele ezalí tɛ́"
 
 #: ../not_found.cgi:32
 msgid "The requested poll was not found."
-msgstr "Le sondage demandé est introuvable."
+msgstr "Litúnele ezalí tɛ́."
 
 #: ../not_found.cgi:33
 msgid "There are several reasons why a poll may have been deleted:"
-msgstr "Il peut y avoir plusieurs explications à la suppression d'un sondage :"
+msgstr "Il peut y avoir plusieurs explications à la suppression d'un sondage:"
 
 #: ../not_found.cgi:34
 msgid "Somebody clicked on “Delete poll” and deleted the poll manually."
@@ -617,11 +617,11 @@ msgstr "Kotínda ekangisi-nkomá na nkandá..."
 
 #: ../overview.rb:35
 msgid "Visit the poll yourself:"
-msgstr "Aller sur le sondage : "
+msgstr "Kokende na litúnele: "
 
 #: ../overview.rb:36
 msgid "Link to DuD-Poll about %{polltitle}"
-msgstr "Ekangisi-nkomá vers le sondage DuD-Poll \"%{polltitle}\""
+msgstr "Ekangisi-nkomá na litúnele DuD-Poll \"%{polltitle}\""
 
 #: ../participate.rb:59
 msgid "The changes were saved, you should be redirected to %{link}."
@@ -631,19 +631,19 @@ msgstr ""
 
 #: ../poll.rb:96
 msgid "Edit user %{user}..."
-msgstr "Éditer l'utilisateur %{user}..."
+msgstr "Kobimisela mosáleli %{user}..."
 
 #: ../poll.rb:100
 msgid "Delete user %{user}..."
-msgstr "Supprimer l'utilisateur %{user}"
+msgstr "Kolímuisa mosáleli %{user}"
 
 #: ../poll.rb:154
 msgid "Total"
-msgstr "Total"
+msgstr "Motúya"
 
 #: ../poll.rb:186
 msgid "Invite"
-msgstr "Inviter"
+msgstr "Kobyánga"
 
 #: ../poll.rb:187 ../pollhead.rb:62 ../timepollhead.rb:158
 msgid "Name"
@@ -652,11 +652,11 @@ msgstr "Nkómbó"
 #: ../poll.rb:229
 #, fuzzy
 msgid "Add a participant"
-msgstr "Inviter des participants"
+msgstr "Kobyánga balandi"
 
 #: ../poll.rb:233
 msgid "Save changes"
-msgstr "Enregistrer les modifications"
+msgstr "Kobómbisa bobóngoami"
 
 #: ../poll.rb:237
 msgid "Cancel"
@@ -704,19 +704,19 @@ msgstr "%{user} a dit à %{time}"
 
 #: ../poll.rb:350
 msgid "Go up"
-msgstr "Vers le haut"
+msgstr "O likoló"
 
 #: ../poll.rb:356
 msgid "says"
-msgstr "dit"
+msgstr "alobí"
 
 #: ../poll.rb:357
 msgid "Submit comment"
-msgstr "Sauvegarder le commentaire"
+msgstr "Kobómbisa linanoli"
 
 #: ../poll.rb:361
 msgid "Enter your name"
-msgstr ""
+msgstr "Kokɔ́ta nkómbó na yɔ̌"
 
 #: ../poll.rb:363
 #, fuzzy
@@ -729,7 +729,7 @@ msgstr "Montrer les éléments de l'historique : "
 
 #: ../poll.rb:382
 msgid "All"
-msgstr "Tous"
+msgstr "Bato bánsɔ"
 
 #: ../poll.rb:383
 msgid "Participant related"
@@ -768,7 +768,7 @@ msgstr "Dernière édition"
 #: ../pollhead.rb:99
 #, fuzzy
 msgid "Option"
-msgstr "Optionnel :"
+msgstr "Lipɔni"
 
 #: ../pollhead.rb:100
 msgid "Description (optional)"
@@ -806,11 +806,11 @@ msgstr "Cette heure est déjà choisie."
 
 #: ../timepollhead.rb:193
 msgid "Earlier"
-msgstr "Plus tôt"
+msgstr "Libosó"
 
 #: ../timepollhead.rb:198
 msgid "Later"
-msgstr "Plus tard"
+msgstr "Nsima"
 
 #: ../timepollhead.rb:265
 msgid "Click on the dates to add or remove columns."
@@ -818,11 +818,11 @@ msgstr "Cliquez sur les dates pour ajouter ou supprimer une colonne."
 
 #: ../timepollhead.rb:313
 msgid "Optional:"
-msgstr "Optionnel:"
+msgstr "Lipɔni:"
 
 #: ../timepollhead.rb:314
 msgid "Select specific start times."
-msgstr "Entrer une heure de début."
+msgstr "Kokɔ́ta ngonga na ebandela."
 
 #: ../timepollhead.rb:330
 msgid "Time"
@@ -838,7 +838,7 @@ msgstr "Lipɔnisi tɛ́"
 
 #: ../timepollhead.rb:345
 msgid "Past"
-msgstr "Passé"
+msgstr "Ntángo eleká"
 
 #: ../timepollhead.rb:379
 msgid "Select the whole row"
@@ -862,7 +862,7 @@ msgstr "ex : 09h30, matin, après-midi"
 #~ "which disturbs you, or have any other feedback."
 #~ msgstr ""
 #~ "Si vous trouvez un bug ou un truc qui vous dérange, indiquez-le moi (de "
-#~ "préférence en anglais ou allemand) : <a href=\"mailto:"
+#~ "préférence en anglais ou allemand): <a href=\"mailto:"
 #~ "Benjamin_dot_Kellermann@gmx_in_deutschland?subject=Dudle%20Feedback"
 #~ "\">Feedback</a>"
 
@@ -875,10 +875,10 @@ msgstr "ex : 09h30, matin, après-midi"
 #~ "l'administrateur du système."
 
 #~ msgid "Event-scheduling poll"
-#~ msgstr "Sondage de choix de date"
+#~ msgstr "Litúnele na mokɔlɔ bopɔni"
 
 #~ msgid "Normal poll"
-#~ msgstr "Sondage normal"
+#~ msgstr "Litúnele-kásá"
 
 #~ msgid "Things you can do now are"
 #~ msgstr "Choses que vous pouvez faire maintenant"
@@ -894,7 +894,7 @@ msgstr "ex : 09h30, matin, après-midi"
 #~ "vcs.org/'>bazaar</a>:"
 
 #~ msgid "The link to your poll is:"
-#~ msgstr "Le lien de votre sondage est :"
+#~ msgstr "Le lien de votre litúnele na yOO ezalí:"
 
 #~ msgid "To the Vote interface"
 #~ msgstr "Vers la page de vote"


### PR DESCRIPTION
Added translation ln (lingala). Some sentences remains in fr.
Lingala spelling following the "Standardisation et uniformisation de l'orthographe des langues nationales du Zaïre" from 1974, the only official spelling rules ever for lingala.