### PR TITLE
Compat with newer Psych: Use safe_load with permitted_classes Poll and TimePollHead

### DIFF
--- a/atom.rb
+++ b/atom.rb
@@ -38,7 +38,7 @@ require_relative "config_defaults"
 require_relative "poll"
 Dir.chdir(olddir)
 
-poll = YAML::load_file("data.yaml")
+poll = YAML::safe_load_file("data.yaml", permitted_classes: [Poll, TimePollHead])
 
 feed.title = poll.name
 feed.id = "urn:dudle:#{poll.class}:#{poll.name}"

--- a/dudle.rb
+++ b/dudle.rb
@@ -125,7 +125,7 @@ class Dudle
 			File.open("last_read_access","w").close unless @cgi.user_agent =~ $conf.bots
 			@basedir = ".."
 			inittabs
-			@table = YAML::load(VCS.cat(self.revision, "data.yaml"))
+			@table = YAML::safe_load(VCS.cat(self.revision, "data.yaml"), permitted_classes: [Poll, TimePollHead])
 			@urlsuffix = File.basename(File.expand_path("."))
 			@title = @table.name
 

--- a/dudle.rb
+++ b/dudle.rb
@@ -132,9 +132,9 @@ class Dudle
 			File.open('last_read_access', 'w').close unless @cgi.user_agent =~ $conf.bots
 			@basedir = '..'
 			inittabs
-		  if params[:revision]
+		  	if params[:revision]
 				@table = YAML.load(VCS.cat(revision, 'data.yaml'))
-   			@table = YAML::safe_load(VCS.cat(self.revision, 'data.yaml'), permitted_classes: [Poll, TimePollHead])
+   				@table = YAML::safe_load(VCS.cat(self.revision, 'data.yaml'), permitted_classes: [Poll, TimePollHead])
 			else
 				@table = YAML.load_file('data.yaml')
 			end

--- a/timepollhead.rb
+++ b/timepollhead.rb
@@ -91,10 +91,10 @@ class TimePollHead
 
 	def parsecolumntitle(title)
 		if $cgi.include?("add_remove_column_day")
-			parsed_date = YAML::load(Time.parse("#{$cgi["add_remove_column_month"]}-#{$cgi["add_remove_column_day"]} #{title}").to_yaml)
+			parsed_date = YAML::safe_load(Time.parse("#{$cgi["add_remove_column_month"]}-#{$cgi["add_remove_column_day"]} #{title}").to_yaml, permitted_classes: [Poll, TimePollHead])
 		else
 			earlytime = @head.keys.collect{|t|t.strftime("%H:%M")}.sort[0]
-			parsed_date = YAML::load(Time.parse("#{$cgi["add_remove_column_month"]}-#{title} #{earlytime}").to_yaml)
+			parsed_date = YAML::safe_load(Time.parse("#{$cgi["add_remove_column_month"]}-#{title} #{earlytime}").to_yaml, permitted_classes: [Poll, TimePollHead])
 		end
 		parsed_date
 	end


### PR DESCRIPTION
Fixes #145, fixes #151

Based on the discussion in #145, @dl8dtl's initial patch suggestion and reading https://docs.ruby-lang.org/en/master/Psych.html to understand the remaining open question by @JoJoDeveloping where the config needs to go.