### PR TITLE
File and Dir exists? replaced with exist?

### DIFF
--- a/check.cgi
+++ b/check.cgi
@@ -43,7 +43,7 @@ hints = []
 
 begin
 
-	hints << "You might want to config your environment within the file 'config.rb' (see 'config_sample.rb' for a starting point)" unless File.exists?("config.rb")
+	hints << "You might want to config your environment within the file 'config.rb' (see 'config_sample.rb' for a starting point)" unless File.exist?("config.rb")
 
 begin
 	require_relative "dudle"
@@ -55,7 +55,7 @@ end
 
 
 
-unless File.exists?("locale/de/dudle.mo")
+unless File.exist?("locale/de/dudle.mo")
 	problems << ["If you want a language other than English, you will need a localization and therefore need to build the .mo files. Refer the README for details."]
 end
 
@@ -63,7 +63,7 @@ unless File.writable?(".")
 	problems << ["Your webserver needs write access to #{File.expand_path(".")}"]
 else
 	testdir = "this-is-a-test-directory-created-by-check.cgi-it-should-be-deleted"
-	if Dir.exists?(testdir) # might exist from a previous test
+	if Dir.exist?(testdir) # might exist from a previous test
 		require "fileutils"
 		FileUtils.rm_r(testdir)
 	end

--- a/config_defaults.rb
+++ b/config_defaults.rb
@@ -65,7 +65,7 @@ $conf.dudle_src = "https://github.com/kellerben/dudle/"
 
 $conf.bots = /bot/i
 
-if File.exists?("config.rb") || File.exists?("../config.rb")
+if File.exist?("config.rb") || File.exist?("../config.rb")
 	require_relative "config"
 end
 

--- a/dudle.rb
+++ b/dudle.rb
@@ -31,7 +31,7 @@ GetText.cgi=$cgi
 GetText.output_charset = 'utf-8'
 require "locale"
 
-if File.exists?("data.yaml") && !File.stat("data.yaml").directory?
+if File.exist?("data.yaml") && !File.stat("data.yaml").directory?
 	$is_poll = true
 	GetText.bindtextdomain("dudle", :path => Dir.pwd + "/../locale/")
 else
@@ -159,7 +159,7 @@ class Dudle
 
 
 		@css = ["default", "classic", "print"].collect{|f| f + ".css"}
-		if Dir.exists?("#{@basedir}/css/")
+		if Dir.exist?("#{@basedir}/css/")
 			Dir.open("#{@basedir}/css/").each{|f|
 				if f =~ /\.css$/
 					@css << "css/#{f}"
@@ -205,11 +205,11 @@ HEAD
 		###################
 		@extensions = []
 		$d = self # FIXME: this is dirty, but extensions need to know table elem
-		if Dir.exists?("#{@basedir}/extensions/") && params[:load_extensions]
+		if Dir.exist?("#{@basedir}/extensions/") && params[:load_extensions]
 			Dir.open("#{@basedir}/extensions/").sort.each{|f|
-				if File.exists?("#{@basedir}/extensions/#{f}/main.rb")
+				if File.exist?("#{@basedir}/extensions/#{f}/main.rb")
 					@extensions << f
-					if File.exists?("#{@basedir}/extensions/#{f}/preload.rb")
+					if File.exist?("#{@basedir}/extensions/#{f}/preload.rb")
 						$current_ext_dir = f
 						require "#{@basedir}/extensions/#{f}/preload"
 					end
@@ -299,7 +299,7 @@ READY
 		@html << "</div>" # main
 		$conf.footer.each{|f| @html << f }
 		@extensions.each{|e|
-			if File.exists?("#{@basedir}/extensions/#{e}/main.rb")
+			if File.exist?("#{@basedir}/extensions/#{e}/main.rb")
 				$current_ext_dir = e
 				require "#{@basedir}/extensions/#{e}/main"
 			end

--- a/error.cgi
+++ b/error.cgi
@@ -21,13 +21,13 @@
 
 require_relative "dudle"
 
-if File.exists?("#{Dir.pwd}/#{File.dirname(ENV["REDIRECT_URL"])}/data.yaml")
+if File.exist?("#{Dir.pwd}/#{File.dirname(ENV["REDIRECT_URL"])}/data.yaml")
 	$d = Dudle.new(:title => _("Error"), :hide_lang_chooser => true, :load_extensions => false, :relative_dir => "../")
 else
 	$d = Dudle.new(:title => _("Error"), :hide_lang_chooser => true, :load_extensions => false)
 end
 
-if File.exists?($conf.errorlog)
+if File.exist?($conf.errorlog)
 	begin
 		a = File.open($conf.errorlog,"r").to_a
 	rescue Exception => e

--- a/example.cgi
+++ b/example.cgi
@@ -39,7 +39,7 @@ if $cgi.include?("poll")
 		if poll[:new_environment]
 			targeturl += "_#{Time.now.to_i}"
 
-			while (File.exists?(targeturl))
+			while (File.exist?(targeturl))
 				targeturl += "I"
 			end
 			VCS.branch(poll[:url],targeturl)

--- a/index.cgi
+++ b/index.cgi
@@ -33,7 +33,7 @@ if $cgi.include?("create_poll") && $cgi.include?("poll_url")
 	else
 		if $cgi["poll_url"] == ""
 			require "securerandom"
-			true while(File.exists?(pollurl = SecureRandom.urlsafe_base64($conf.random_chars)))
+			true while(File.exist?(pollurl = SecureRandom.urlsafe_base64($conf.random_chars)))
 		else
 			pollurl=$cgi["poll_url"]
 		end

--- a/maintenance.cgi
+++ b/maintenance.cgi
@@ -27,7 +27,7 @@ else
 	$d = Dudle.new(:title => _("Maintenance"), :hide_lang_chooser => true)
 end
 
-if File.exists?("maintenance.html")
+if File.exist?("maintenance.html")
 	$d << _("This site is currently undergoing maintenance!")
 	$d << File.open("maintenance.html","r").read
 else

--- a/not_found.cgi
+++ b/not_found.cgi
@@ -21,7 +21,7 @@
 
 if(ENV["REDIRECT_URL"])
 require_relative "dudle"
-if File.exists?(Dir.pwd + File.dirname(ENV["REDIRECT_URL"]))
+if File.exist?(Dir.pwd + File.dirname(ENV["REDIRECT_URL"]))
 	$d = Dudle.new(:hide_lang_chooser => true, :load_extensions => false)
 else
 	$d = Dudle.new(:hide_lang_chooser => true, :load_extensions => false, :relative_dir => "../")

--- a/participate.rb
+++ b/participate.rb
@@ -60,7 +60,7 @@ if edit
 
 else
 
-$d.html.add_atom("atom.cgi") if File.exists?("../atom.rb")
+$d.html.add_atom("atom.cgi") if File.exist?("../atom.rb")
 
 # TABLE
 $d << <<HTML


### PR DESCRIPTION
See e.g. https://bugs.ruby-lang.org/issues/17391 -- the `exists?` variants were deprecated in ruby 2.1 and removed in 3.2.

The `exist?` variants seem to be already present in 1.9.1 (see [1] and [2]), so shouldn't affect our list of supported versions.

[1]: https://ruby-doc.org/core-1.9.1/Dir.html#method-c-exist-3F
[2]: https://ruby-doc.org/core-1.9.1/File.html#method-c-exist-3F

(Note that other changes were needed to run on latest ruby for me, this is just the one that seems easiest / least controversial)